### PR TITLE
Refactor 09 & add some shared functions

### DIFF
--- a/Scripts/09-Storm.py
+++ b/Scripts/09-Storm.py
@@ -6,34 +6,8 @@ __doc__="""
 
 import GlyphsApp
 from NaNGFGraphikshared import *
-from NaNGFAngularizzle import *
 from NaNGFNoise import *
 from NaNFilter import NaNFilter
-from Foundation import NSMakePoint
-
-def withinGlyphBlack_faster(layer, x, y):
-	if not layer.bounds:
-		return
-	definitelyOutside = NSMakePoint(layer.bounds.origin.x-1,y)
-	pt = NSMakePoint(x,y)
-	intersections = layer.calculateIntersectionsStartPoint_endPoint_decompose_(definitelyOutside, pt, True)
-	return (len(intersections) % 2) == 1
-
-def operateOnBlackAtInterval(layer, func, step_x, step_y=None):
-	if step_y is None:
-		step_y = step_x
-	b = AllPathBounds(layer)
-	ox, oy, w, h = int(b[0])+1, b[1]+1, b[2], b[3]
-	results = []
-	for y in range(oy, oy+h, step_y):
-		for x in range(ox, ox+w, step_x):
-			if not withinGlyphBlack_faster(layer, x, y):
-				continue
-			result = func(x,y,layer)
-			if result is not None:
-				results.extend(result)
-
-	return results
 
 class Storm(NaNFilter):
 	gridsize, minsize, maxsize = 25, 20, 60

--- a/Scripts/NaNGFGraphikshared.py
+++ b/Scripts/NaNGFGraphikshared.py
@@ -5,6 +5,7 @@ import random
 import copy
 import numpy as np
 import matplotlib.path as mpltPath
+from Foundation import NSMakePoint
 
 from NaNGFConfig import *
 from NaNGFAngularizzle import *
@@ -113,6 +114,29 @@ def withinGlyphBlack(x, y, glyph):
 	else:
 		return False # not
 
+def withinLayerBlack(layer, x, y):
+	if not layer.bounds:
+		return
+	definitelyOutside = NSMakePoint(layer.bounds.origin.x-1,y)
+	pt = NSMakePoint(x,y)
+	intersections = layer.calculateIntersectionsStartPoint_endPoint_decompose_(definitelyOutside, pt, True)
+	return (len(intersections) % 2) == 1
+
+def operateOnBlackAtInterval(layer, func, step_x, step_y=None):
+	if step_y is None:
+		step_y = step_x
+	b = AllPathBounds(layer)
+	ox, oy, w, h = int(b[0])+1, b[1]+1, b[2], b[3]
+	results = []
+	for y in range(oy, oy+h, step_y):
+		for x in range(ox, ox+w, step_x):
+			if not withinLayerBlack(layer, x, y):
+				continue
+			result = func(x,y,layer)
+			if result is not None:
+				results.extend(result)
+
+	return results
 
 def point_inside_polygon_faster(x,y,poly):
 


### PR DESCRIPTION
This refactor is a bit different because it adds two useful functions to `NaNGFGraphikshared`: `withinLayerBlack(layer, x, y)` uses the approach I mentioned in #1 to find if a point is within the black or not. This allows you to do that computation without having to call `angularizzle` etc. which in turn makes things a lot simpler. The second function is `operateOnBlackAtInterval(layer, func, step_x, step_y=None)` which steps over the layer in a grid and calls `func(x,y,layer)` (you pass in a function) for each black point in the grid.

On another refactoring pass we will have to go back and look at the previous scripts and see if they use this do-things-on-a-grid pattern. I will use it where possible for scripts >9 though.